### PR TITLE
Bumps build number and adds usage descriptions

### DIFF
--- a/BiomarinPKU/BiomarinPKU/Info.plist
+++ b/BiomarinPKU/BiomarinPKU/Info.plist
@@ -32,11 +32,19 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>This permission is not needed for the study, please decline this permission if prompted.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>This permission is not needed for the study, please decline this permission if prompted.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This permission is not needed for the study, please decline this permission if prompted.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Required for certain assessments.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>pkYou would like to access your phone&apos;s motion sensors to help gather data during activities.</string>
+	<string>pkYou would like to access your phone's motion sensors to help gather data during activities.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>lato_black.ttf</string>
@@ -51,8 +59,6 @@
 	<array/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Required for certain assessments.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
In order to distribute through TestFlight, need to add the changes here, particularly the one about bluetooth access which likely comes from the Brain Baseline libraries (not under our control).