### PR TITLE
After week 1 home screen

### DIFF
--- a/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
@@ -161,6 +161,22 @@ public enum ActivityType: Int, CaseIterable {
         return ((dayOfStudy - 1) / 7) + 1
     }
     
+    static func dailyTypes(for day: Int) -> [ActivityType] {
+        var dailyTypes: [ActivityType] = [.daily, .sleep]
+        if day <= 7 {
+            dailyTypes.append(contentsOf: [.physical, .cognition])
+        }
+        return dailyTypes
+    }
+    
+    static func weeklyTypes(for day: Int) -> [ActivityType] {
+        var weeklyTypes = [ActivityType]()
+        if day > 7 {
+            weeklyTypes.append(contentsOf: [.physical, .cognition])
+        }
+        return weeklyTypes
+    }
+    
     func taskIdentifier(for day: Int) -> String {
         let week = self.weekOfStudy(dayOfStudy: day)
         switch self {
@@ -236,16 +252,40 @@ public enum ActivityType: Int, CaseIterable {
         }
     }
     
-    func detail() -> String {
+    func detail(for day: Int, isComplete: Bool) -> String {
         switch self {
         case .sleep:
-            return Localization.localizedString("MINUTES_SLEEP")
+            if !isComplete {
+                return Localization.localizedString("MINUTES_SLEEP")
+            } else {
+                return Localization.localizedString("DONE_FOR_DAY")
+            }
         case .physical:
-            return Localization.localizedString("MINUTES_PHYSICAL")
+            if !isComplete {
+                return Localization.localizedString("MINUTES_PHYSICAL")
+            } else {
+                if day <= 7 {
+                    return Localization.localizedString("DONE_FOR_DAY")
+                } else {
+                    return Localization.localizedString("DONE_FOR_WEEK")
+                }
+            }
         case .cognition:
-            return Localization.localizedString("MINUTES_COGNITION")
+            if !isComplete {
+                return Localization.localizedString("MINUTES_COGNITION")
+            } else {
+                if day <= 7 {
+                    return Localization.localizedString("DONE_FOR_DAY")
+                } else {
+                    return Localization.localizedString("DONE_FOR_WEEK")
+                }
+            }
         case .daily:
-            return Localization.localizedString("MINUTES_DAILY")
+            if !isComplete {
+                return Localization.localizedString("MINUTES_DAILY")
+            } else {
+                return Localization.localizedString("DONE_FOR_DAY")
+            }
         }
     }
     

--- a/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
@@ -52,6 +52,10 @@ public class ActivityScheduleManager : SBAScheduleManager {
         return self.dayOfStudy(at: today)
     }
     
+    open func weekOfStudy(dayOfStudy: Int) -> Int {
+        return ActivityType.daily.weekOfStudy(dayOfStudy: dayOfStudy)
+    }
+    
     open var studyStartDate: Date {
         // The activites are scheduled when the user first requests them
         // Therefore, the day the user first signed in and started their study,

--- a/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
@@ -290,28 +290,19 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         
         let dayOfStudy = scheduleManager.dayOfStudy()
         let weekOfStudy = scheduleManager.weekOfStudy(dayOfStudy: dayOfStudy)
-        if dayOfStudy <= 7 {
-            self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
-            self.expiresWeeklyLabel.text = nil
-            self.dayTitleLabel.text = Localization.localizedString(Localization.localizedString("WEEK_1_DAY"))
-            self.dayLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_DAY_FORMAT_%@", String(dayOfStudy))
-        } else {
-            self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
-            
-            let daysUntilWeeklyExpiration = (weekOfStudy * 7) - dayOfStudy + 1
-            if daysUntilWeeklyExpiration <= 1 {
-                self.expiresWeeklyLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@", expiresTimeStr)
-            } else {
-                self.expiresWeeklyLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_DAYS_%@", String(daysUntilWeeklyExpiration))
-            }
-            
-            self.dayTitleLabel.text = Localization.localizedString(Localization.localizedString("WEEK"))
-            self.dayLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_DAY_FORMAT_%@", String(weekOfStudy))
-        }
         
+        self.expiresLabel.text = self.expiresLabelText(for: dayOfStudy, expiresTimeStr: expiresTimeStr)
+        self.expiresWeeklyLabel.text = self.expiresWeeklyLabelText(for: dayOfStudy, week: weekOfStudy, expiresTimeStr: expiresTimeStr)
+        self.dayLabel.text = self.dayLabelText(for: dayOfStudy, week: weekOfStudy)
+        self.dayTitleLabel.text = self.dayTitleLabelText(for: dayOfStudy)
+        
+        // Check for day crossover
         if let previous = self.expirationgDay,
             dayOfStudy != previous {
+            // Reload data on day crossover so new activities can be done
             self.scheduleManager.reloadData()
+            
+            // Check for week 1 complete crossover and run task if so
             if dayOfStudy == 8 && self.shouldRunWeek1CompleteTask() {
                 self.runWeek1CompelteTask()
             }
@@ -320,6 +311,43 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         // Keep track of previous day and week so we can determine
         // when day and week thresholds are passed
         self.expirationgDay = dayOfStudy
+    }
+    
+    func expiresLabelText(for day: Int, expiresTimeStr: String) -> String? {
+        if day <= 7 {
+            return Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
+        } else {
+            return Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
+        }
+    }
+    
+    func expiresWeeklyLabelText(for day: Int, week: Int, expiresTimeStr: String) -> String? {
+        if day <= 7 {
+            return nil
+        } else {
+            let daysUntilWeeklyExpiration = (week * 7) - day + 1
+            if daysUntilWeeklyExpiration <= 1 {
+                return Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@", expiresTimeStr)
+            } else {
+                return Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_DAYS_%@", String(daysUntilWeeklyExpiration))
+            }
+        }
+    }
+    
+    func dayLabelText(for day: Int, week: Int) -> String? {
+        if day <= 7 {
+            return Localization.localizedStringWithFormatKey("WEEK_1_DAY_FORMAT_%@", String(day))
+        } else {
+            return Localization.localizedStringWithFormatKey("AFTER_WEEK_1_DAY_FORMAT_%@", String(week))
+        }
+    }
+    
+    func dayTitleLabelText(for day: Int) -> String? {
+        if day <= 7 {
+            return Localization.localizedString(Localization.localizedString("WEEK_1_DAY"))
+        } else {
+            return Localization.localizedString(Localization.localizedString("WEEK"))
+        }
     }
     
     func timeUntilExpiration(from now: Date, until expiration: Date) -> String {

--- a/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
@@ -298,7 +298,7 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         } else {
             self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
             
-            let daysUntilWeeklyExpiration = (weekOfStudy * 7) - dayOfStudy
+            let daysUntilWeeklyExpiration = (weekOfStudy * 7) - dayOfStudy + 1
             if daysUntilWeeklyExpiration <= 1 {
                 self.expiresWeeklyLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@", expiresTimeStr)
             } else {

--- a/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
@@ -74,8 +74,9 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
     // The end study button
     @IBOutlet public var endStudyButton: UIButton!
     
-    // The expires time label
+    // The expires time label for daily and weekly
     @IBOutlet public var expiresLabel: UILabel!
+    @IBOutlet public var expiresWeeklyLabel: UILabel!
     
     // The loading view for when the schedules are being loaded
     @IBOutlet public var loadingView: UIActivityIndicatorView!
@@ -89,6 +90,7 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
     @IBOutlet var activityDoneIcons: Array<UIImageView>?
     
     var expirationTimer = Timer()
+    var expirationgDay: Int?
     
     let scheduleManager = ActivityScheduleManager.shared
     
@@ -128,6 +130,12 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         
         // Schedule expiration timer to run every second
         self.expirationTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(self.updateTimeFormattedText), userInfo: nil, repeats: true)
+        
+        // Only set this on load, otheriwse the buttons flash when switching tabs
+        for activity in ActivityType.allCases {
+            let i = activity.rawValue
+            self.activityButtons?[i].setTitle(activity.title(), for: .normal)
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -169,6 +177,9 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         self.expiresLabel.font = designSystem.fontRules.font(for: .italicDetail)
         self.expiresLabel.textColor = designSystem.colorRules.textColor(on: backgroundLight, for: .italicDetail)
         
+        self.expiresWeeklyLabel.font = designSystem.fontRules.font(for: .italicDetail)
+        self.expiresWeeklyLabel.textColor = designSystem.colorRules.textColor(on: backgroundLight, for: .italicDetail)
+        
         self.accountDetailsContainer.backgroundColor = backgroundLight.color
         
         self.accountDetailsButton.titleLabel?.font = designSystem.fontRules.font(for: .microDetail)
@@ -190,7 +201,6 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
     func refreshUI() {
         self.titleLabel.text = Localization.localizedString("WEEK_1_TITLE")
         self.textLabel.text = Localization.localizedString("WEEK_1_TEXT")
-        self.dayTitleLabel.text = Localization.localizedString("WEEK_1_DAY")
     self.accountDetailsButton.setTitle(Localization.localizedString("VIEW_ACCOUNT_DETAILS"), for: .normal)
         
         // Setup external ID to display as XXXX - XXXXX
@@ -202,7 +212,6 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
         
         for activity in ActivityType.allCases {
             let i = activity.rawValue
-            self.activityButtons?[i].setTitle(activity.title(), for: .normal)
             self.activityDetailLabels?[i].text = activity.detail()
             let isComplete = activity.isComplete(for: scheduleManager.dayOfStudy())
             self.activityButtons?[i].isEnabled = !isComplete
@@ -279,11 +288,38 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
     @objc func updateTimeFormattedText() {
         let expiresTimeStr = self.timeUntilExpiration(from: Date(), until: Calendar.current.startOfDay(for: Date()).addingNumberOfDays(1))
         
-        self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
+        let dayOfStudy = scheduleManager.dayOfStudy()
+        let weekOfStudy = scheduleManager.weekOfStudy(dayOfStudy: dayOfStudy)
+        if dayOfStudy <= 7 {
+            self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
+            self.expiresWeeklyLabel.text = nil
+            self.dayTitleLabel.text = Localization.localizedString(Localization.localizedString("WEEK_1_DAY"))
+            self.dayLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_DAY_FORMAT_%@", String(dayOfStudy))
+        } else {
+            self.expiresLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_EXPIRES_FORMAT_%@", expiresTimeStr)
+            
+            let daysUntilWeeklyExpiration = (weekOfStudy * 7) - dayOfStudy
+            if daysUntilWeeklyExpiration <= 1 {
+                self.expiresWeeklyLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@", expiresTimeStr)
+            } else {
+                self.expiresWeeklyLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_DAYS_%@", String(daysUntilWeeklyExpiration))
+            }
+            
+            self.dayTitleLabel.text = Localization.localizedString(Localization.localizedString("WEEK"))
+            self.dayLabel.text = Localization.localizedStringWithFormatKey("AFTER_WEEK_1_DAY_FORMAT_%@", String(weekOfStudy))
+        }
         
-        self.dayLabel.text = Localization.localizedStringWithFormatKey("WEEK_1_DAY_FORMAT_%@", String(scheduleManager.dayOfStudy()))
+        if let previous = self.expirationgDay,
+            dayOfStudy != previous {
+            self.scheduleManager.reloadData()
+            if dayOfStudy == 8 && self.shouldRunWeek1CompleteTask() {
+                self.runWeek1CompelteTask()
+            }
+        }
         
-        // TODO: mdephillips 8/10/19 check for and transition past the first week of the study if applicable
+        // Keep track of previous day and week so we can determine
+        // when day and week thresholds are passed
+        self.expirationgDay = dayOfStudy
     }
     
     func timeUntilExpiration(from now: Date, until expiration: Date) -> String {

--- a/BiomarinPKU/BiomarinPKU-Study/Base.lproj/Main.storyboard
+++ b/BiomarinPKU/BiomarinPKU-Study/Base.lproj/Main.storyboard
@@ -145,7 +145,7 @@
                                     <constraint firstItem="ZJA-Nk-9ka" firstAttribute="top" secondItem="LCA-S0-ZPp" secondAttribute="top" constant="4" id="oxz-BK-G6n"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today’s activities expire in 00:59:04" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9TO-gf-s8t" userLabel="Expires">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today’s activities expire in 00:59:04" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9TO-gf-s8t" userLabel="Expires">
                                 <rect key="frame" x="24" y="364" width="366" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -210,26 +210,26 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZDL-Qk-Kd4" customClass="RSDUnderlinedButton" customModule="ResearchUI">
                                                         <rect key="frame" x="0.0" y="0.0" width="207" height="210"/>
                                                         <inset key="titleEdgeInsets" minX="0.0" minY="36" maxX="0.0" maxY="0.0"/>
-                                                        <state key="normal" title="Physical Challenge"/>
+                                                        <state key="normal" title="Daily Check-In"/>
                                                         <connections>
-                                                            <action selector="physicalTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="t6k-Gf-qF6"/>
+                                                            <action selector="dailyCheckInTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="cjS-Jt-DLF"/>
                                                         </connections>
                                                     </button>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 minutes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-wg-tY1">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 minute" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-wg-tY1">
                                                         <rect key="frame" x="0.0" y="135" width="207" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityIconPhysical" translatesAutoresizingMaskIntoConstraints="NO" id="GTg-dN-eqn" userLabel="Activity Icon">
-                                                        <rect key="frame" x="71.5" y="49" width="64" height="64"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityIconDaily" translatesAutoresizingMaskIntoConstraints="NO" id="GTg-dN-eqn" userLabel="Activity Icon">
+                                                        <rect key="frame" x="76.5" y="54" width="54" height="54"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="GTg-dN-eqn" secondAttribute="height" multiplier="1:1" id="UDs-e8-1Rk"/>
-                                                            <constraint firstAttribute="width" constant="64" id="cmg-Ko-HzR"/>
+                                                            <constraint firstAttribute="width" constant="54" id="cmg-Ko-HzR"/>
                                                         </constraints>
                                                     </imageView>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityDoneIcon" translatesAutoresizingMaskIntoConstraints="NO" id="GPy-TC-p8w" userLabel="Done">
-                                                        <rect key="frame" x="123.5" y="37" width="24" height="24"/>
+                                                        <rect key="frame" x="118.5" y="42" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="24" id="jtc-Wf-JB2"/>
                                                             <constraint firstAttribute="width" secondItem="GPy-TC-p8w" secondAttribute="height" multiplier="1:1" id="p0r-79-I37"/>
@@ -320,26 +320,26 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pz7-4l-jRD" customClass="RSDUnderlinedButton" customModule="ResearchUI">
                                                         <rect key="frame" x="0.0" y="0.0" width="207" height="210"/>
                                                         <inset key="titleEdgeInsets" minX="0.0" minY="36" maxX="0.0" maxY="0.0"/>
-                                                        <state key="normal" title="Daily Check-In"/>
+                                                        <state key="normal" title="Physical Challenge"/>
                                                         <connections>
-                                                            <action selector="dailyCheckInTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="IE1-vQ-bh8"/>
+                                                            <action selector="physicalTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="u6G-Zo-dQy"/>
                                                         </connections>
                                                     </button>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1 minute" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i7e-4Z-P6j">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 minutes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i7e-4Z-P6j">
                                                         <rect key="frame" x="0.0" y="135" width="207" height="24"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityIconDaily" translatesAutoresizingMaskIntoConstraints="NO" id="50r-C5-DLZ" userLabel="Activity Icon">
-                                                        <rect key="frame" x="76.5" y="54" width="54" height="54"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityIconPhysical" translatesAutoresizingMaskIntoConstraints="NO" id="50r-C5-DLZ" userLabel="Activity Icon">
+                                                        <rect key="frame" x="71.5" y="49" width="64" height="64"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="54" id="KCk-pG-aTc"/>
+                                                            <constraint firstAttribute="width" constant="64" id="KCk-pG-aTc"/>
                                                             <constraint firstAttribute="width" secondItem="50r-C5-DLZ" secondAttribute="height" multiplier="1:1" id="Rfo-3o-wMN"/>
                                                         </constraints>
                                                     </imageView>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ActivityDoneIcon" translatesAutoresizingMaskIntoConstraints="NO" id="LTH-JD-EEG" userLabel="Done">
-                                                        <rect key="frame" x="118.5" y="42" width="24" height="24"/>
+                                                        <rect key="frame" x="123.5" y="37" width="24" height="24"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="24" id="ekC-6B-yoq"/>
                                                             <constraint firstAttribute="width" secondItem="LTH-JD-EEG" secondAttribute="height" multiplier="1:1" id="euO-c5-ixR"/>
@@ -382,15 +382,24 @@
                                         </constraints>
                                     </view>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="zmk-N3-BfY">
-                                        <rect key="frame" x="188.5" y="191.5" width="37" height="37"/>
+                                        <rect key="frame" x="188.5" y="159.5" width="37" height="37"/>
                                         <color key="color" red="0.96078431369999995" green="0.70196078429999997" blue="0.23529411759999999" alpha="1" colorSpace="calibratedRGB"/>
                                     </activityIndicatorView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This week’s activities expire in 00:59:04" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="JmT-pT-FDC" userLabel="Expires Week">
+                                        <rect key="frame" x="24" y="199.5" width="366" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="JmT-pT-FDC" secondAttribute="trailing" constant="24" id="5ub-Kh-QUu"/>
                                     <constraint firstItem="b4Y-5N-ZoH" firstAttribute="leading" secondItem="OIe-gP-crF" secondAttribute="leading" id="ETX-nV-zOa"/>
                                     <constraint firstItem="iVJ-dD-aDr" firstAttribute="top" secondItem="OIe-gP-crF" secondAttribute="top" id="Erp-uc-MUE"/>
+                                    <constraint firstItem="JmT-pT-FDC" firstAttribute="centerY" secondItem="OIe-gP-crF" secondAttribute="centerY" id="MNp-ZK-Bj0"/>
                                     <constraint firstAttribute="trailing" secondItem="b4Y-5N-ZoH" secondAttribute="trailing" id="ayl-Ku-nJx"/>
+                                    <constraint firstItem="JmT-pT-FDC" firstAttribute="leading" secondItem="OIe-gP-crF" secondAttribute="leading" constant="24" id="bMe-eG-I3B"/>
                                     <constraint firstAttribute="trailing" secondItem="iVJ-dD-aDr" secondAttribute="trailing" id="cnG-6y-aC1"/>
                                     <constraint firstAttribute="trailing" secondItem="VUh-EG-d2l" secondAttribute="trailing" id="hBB-xq-9d9"/>
                                     <constraint firstItem="VUh-EG-d2l" firstAttribute="leading" secondItem="OIe-gP-crF" secondAttribute="leading" id="ha6-Ox-20G"/>
@@ -400,7 +409,7 @@
                                     <constraint firstAttribute="bottom" secondItem="b4Y-5N-ZoH" secondAttribute="bottom" id="tJq-VR-QT4"/>
                                     <constraint firstItem="iVJ-dD-aDr" firstAttribute="height" secondItem="VUh-EG-d2l" secondAttribute="height" id="urV-Ga-17K"/>
                                     <constraint firstAttribute="bottom" secondItem="VUh-EG-d2l" secondAttribute="bottom" id="vpV-fS-hRA"/>
-                                    <constraint firstItem="zmk-N3-BfY" firstAttribute="centerY" secondItem="OIe-gP-crF" secondAttribute="centerY" id="xNx-Ii-PqI"/>
+                                    <constraint firstItem="zmk-N3-BfY" firstAttribute="centerY" secondItem="OIe-gP-crF" secondAttribute="centerY" constant="-32" id="xNx-Ii-PqI"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -446,22 +455,23 @@
                         <outlet property="dayTitleLabel" destination="6cG-Lh-7hq" id="tX0-dZ-SRh"/>
                         <outlet property="endStudyButton" destination="Ukb-hf-m90" id="5eT-xS-M6d"/>
                         <outlet property="expiresLabel" destination="9TO-gf-s8t" id="Suu-ck-Z05"/>
+                        <outlet property="expiresWeeklyLabel" destination="JmT-pT-FDC" id="BGb-fC-kXe"/>
                         <outlet property="headerBackground" destination="TMi-WH-FvO" id="awp-Ur-kCW"/>
                         <outlet property="loadingView" destination="zmk-N3-BfY" id="OmM-mo-WtD"/>
                         <outlet property="textLabel" destination="PPv-hi-3vG" id="R0e-ed-kVo"/>
                         <outlet property="titleLabel" destination="164-7P-iie" id="Hzw-tV-XpD"/>
-                        <outletCollection property="activityButtons" destination="8eY-FH-NqM" collectionClass="NSMutableArray" id="Ru0-AX-JQL"/>
-                        <outletCollection property="activityDetailLabels" destination="PWj-Vn-pqA" collectionClass="NSMutableArray" id="mu9-3z-DyB"/>
-                        <outletCollection property="activityDoneIcons" destination="kLH-1Z-04g" collectionClass="NSMutableArray" id="j9Y-3p-F7Y"/>
-                        <outletCollection property="activityButtons" destination="ZDL-Qk-Kd4" collectionClass="NSMutableArray" id="Pvp-Eb-SYX"/>
-                        <outletCollection property="activityDetailLabels" destination="Kpm-wg-tY1" collectionClass="NSMutableArray" id="aEY-2Z-fj6"/>
-                        <outletCollection property="activityDoneIcons" destination="GPy-TC-p8w" collectionClass="NSMutableArray" id="1Mk-p5-Zhe"/>
-                        <outletCollection property="activityButtons" destination="uMC-xi-Afl" collectionClass="NSMutableArray" id="64r-fO-zij"/>
-                        <outletCollection property="activityDetailLabels" destination="sfW-om-r6p" collectionClass="NSMutableArray" id="A71-hz-V4h"/>
-                        <outletCollection property="activityDoneIcons" destination="Uwk-WM-9qD" collectionClass="NSMutableArray" id="QEG-FF-wuv"/>
-                        <outletCollection property="activityButtons" destination="pz7-4l-jRD" collectionClass="NSMutableArray" id="HaD-Iu-dzK"/>
-                        <outletCollection property="activityDetailLabels" destination="i7e-4Z-P6j" collectionClass="NSMutableArray" id="sfr-qL-9rE"/>
-                        <outletCollection property="activityDoneIcons" destination="LTH-JD-EEG" collectionClass="NSMutableArray" id="mhX-Pj-K9o"/>
+                        <outletCollection property="activityButtons" destination="8eY-FH-NqM" collectionClass="NSMutableArray" id="UPZ-3J-1mQ"/>
+                        <outletCollection property="activityButtons" destination="pz7-4l-jRD" collectionClass="NSMutableArray" id="ynx-gG-WvO"/>
+                        <outletCollection property="activityButtons" destination="uMC-xi-Afl" collectionClass="NSMutableArray" id="glU-07-UMq"/>
+                        <outletCollection property="activityButtons" destination="ZDL-Qk-Kd4" collectionClass="NSMutableArray" id="B6J-Ts-OBg"/>
+                        <outletCollection property="activityDetailLabels" destination="PWj-Vn-pqA" collectionClass="NSMutableArray" id="Ze4-vL-vE4"/>
+                        <outletCollection property="activityDetailLabels" destination="i7e-4Z-P6j" collectionClass="NSMutableArray" id="v75-nY-Tc6"/>
+                        <outletCollection property="activityDetailLabels" destination="sfW-om-r6p" collectionClass="NSMutableArray" id="RKf-G5-Oxi"/>
+                        <outletCollection property="activityDetailLabels" destination="Kpm-wg-tY1" collectionClass="NSMutableArray" id="u4L-OF-mwD"/>
+                        <outletCollection property="activityDoneIcons" destination="kLH-1Z-04g" collectionClass="NSMutableArray" id="HJz-KH-CGX"/>
+                        <outletCollection property="activityDoneIcons" destination="LTH-JD-EEG" collectionClass="NSMutableArray" id="Nsa-nx-ytQ"/>
+                        <outletCollection property="activityDoneIcons" destination="Uwk-WM-9qD" collectionClass="NSMutableArray" id="Dka-VV-W2k"/>
+                        <outletCollection property="activityDoneIcons" destination="GPy-TC-p8w" collectionClass="NSMutableArray" id="3A7-cj-DYB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -498,7 +508,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="separatorColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="sectionIndexBackgroundColor" red="0.96078431369999995" green="0.70196078429999997" blue="0.23529411759999999" alpha="1" colorSpace="calibratedRGB"/>
-                        <view key="tableHeaderView" contentMode="scaleAspectFit" id="omF-LR-gLS" customClass="PKUTaskTableHeaderView" customModule="BiomarinPKU" customModuleProvider="target">
+                        <view key="tableHeaderView" contentMode="scaleAspectFit" id="omF-LR-gLS" customClass="PKUTaskTableHeaderView" customModule="BiomarinPKU_Study" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="211"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>

--- a/BiomarinPKU/BiomarinPKU/Base.lproj/Attentional Blink.json
+++ b/BiomarinPKU/BiomarinPKU/Base.lproj/Attentional Blink.json
@@ -14,7 +14,7 @@
             },
             "measurements"  : "How well you can focus across time.",
             "yourObjective" : "A stream of letters will be presented rapidly at the center of the screen. Your task is to watch this stream and watch for two different occurances.",
-            "instructions"  : "You will watch a stream of letters at the center of the screen and look for the RED letter and whether there was an X. When the stream ends, you will be asked to  identify the red letter, which will always be a B, D, or S.\n\nYou will also be asked if you saw an X or not.",
+            "instructions"  : "You will watch a stream of letters at the center of the screen and look for the RED letter and whether there was an X. When the stream ends, you will be asked to  identify the red letter, which will always be a B, G, or S.\n\nYou will also be asked if you saw an X or not.",
             "actions": {
                 "goForward": {
                     "type": "default",

--- a/BiomarinPKU/BiomarinPKU/PKU.strings
+++ b/BiomarinPKU/BiomarinPKU/PKU.strings
@@ -61,11 +61,16 @@
 "REMINDER_PHYSICAL_TITLE" = "Time for your physical challenge";
 
 "WEEK_1_DAY" = "Day";
+"WEEK" = "Week";
 "WEEK_1_DAY_FORMAT_%@" = "%@ of 7";
+"AFTER_WEEK_1_DAY_FORMAT_%@" = "%@";
 "WEEK_1_TITLE" = "Let’s begin your journey!";
 "WEEK_1_TEXT" = "By completing your first 4 activities in a day for one week, you will then be able to unlock your entire journey.";
 "WEEK_1_EXPIRES_FORMAT_%@" = "Today’s activities expire in %@";
+"AFTER_WEEK_1_EXPIRES_FORMAT_%@" = "Daily activities expire in %@";
 "WEEK_1_ACTIVITY_SLEEP" = "Sleep Check-In";
+"AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_DAYS_%@" = "Weekly activities expire in %@ days";
+"AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@" = "Weekly activities expire in %@";
 
 "ACTIVITY_PHYSICAL" = "Physical Challenge";
 "ACTIVITY_COGNITION" = "Cognition";

--- a/BiomarinPKU/BiomarinPKU/PKU.strings
+++ b/BiomarinPKU/BiomarinPKU/PKU.strings
@@ -65,15 +65,23 @@
 "WEEK_1_DAY_FORMAT_%@" = "%@ of 7";
 "AFTER_WEEK_1_DAY_FORMAT_%@" = "%@";
 "WEEK_1_TITLE" = "Let’s begin your journey!";
+"AFTER_WEEK_1_TITLE" = "Continuing your journey";
 "WEEK_1_TEXT" = "By completing your first 4 activities in a day for one week, you will then be able to unlock your entire journey.";
+"AFTER_WEEK_1_TEXT" = "In this phase of the study, please do your check-ins once per day and your challenges once per week.";
 "WEEK_1_EXPIRES_FORMAT_%@" = "Today’s activities expire in %@";
+"WEEK_1_RENEW_FORMAT_%@" = "Today’s activities renew in %@";
 "AFTER_WEEK_1_EXPIRES_FORMAT_%@" = "Daily activities expire in %@";
+"AFTER_WEEK_1_RENEW_FORMAT_%@" = "Daily activities renew in %@";
 "WEEK_1_ACTIVITY_SLEEP" = "Sleep Check-In";
 "AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_DAYS_%@" = "Weekly activities expire in %@ days";
 "AFTER_WEEK_1_EXPIRES_WEEKLY_FORMAT_HOURS_%@" = "Weekly activities expire in %@";
+"AFTER_WEEK_1_RENEW_WEEKLY_FORMAT_DAYS_%@" = "Weekly activities renew in %@ days";
+"AFTER_WEEK_1_RENEW_WEEKLY_FORMAT_HOURS_%@" = "Weekly activities renew in %@";
+"DONE_FOR_DAY" = "Done for day";
+"DONE_FOR_WEEK" = "Done for week";
 
 "ACTIVITY_PHYSICAL" = "Physical Challenge";
-"ACTIVITY_COGNITION" = "Cognition";
+"ACTIVITY_COGNITION" = "Cognitive Challenge";
 "ACTIVITY_DAILY" = "Daily Check-In";
 "ACTIVITY_SLEEP" = "Sleep Check-In";
 "MINUTES_SLEEP" = "1 minute";

--- a/BiomarinPKU/BiomarinPKUStudyTests/ActivityScheduleManagerTests.swift
+++ b/BiomarinPKU/BiomarinPKUStudyTests/ActivityScheduleManagerTests.swift
@@ -242,6 +242,24 @@ class ActivityScheduleManagerTests: XCTestCase {
         XCTAssertEqual(ActivityType.daily.weekOfStudy(dayOfStudy: scheduleManager.dayOfStudy()), 2)
     }
     
+    func testDaliyTypesTest() {
+        for dayIdx in 1...7 {
+            XCTAssertEqual(ActivityType.dailyTypes(for: dayIdx).count, 4)
+        }
+        for dayIdx in 8...21 {
+            XCTAssertEqual(ActivityType.dailyTypes(for: dayIdx).count, 2)
+        }
+    }
+    
+    func testWeeklyTypesTest() {
+        for dayIdx in 1...7 {
+            XCTAssertEqual(ActivityType.weeklyTypes(for: dayIdx).count, 0)
+        }
+        for dayIdx in 8...21 {
+            XCTAssertEqual(ActivityType.weeklyTypes(for: dayIdx).count, 2)
+        }
+    }
+    
     private func studyDate(_ day: Int, _ hour: Int, _ min: Int, _ sec: Int) -> Date {
         return Calendar.current.date(from: DateComponents(year: 2019, month: 8, day: day, hour: hour, minute: min, second: sec))!
     }

--- a/BiomarinPKU/BiomarinPKUStudyTests/ActivityViewControllerTests.swift
+++ b/BiomarinPKU/BiomarinPKUStudyTests/ActivityViewControllerTests.swift
@@ -69,6 +69,54 @@ class ActivityViewControllerTests: XCTestCase {
         XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "12:48:49")
     }
     
+    func testExpiresLabelText() {
+        for dayIdx in 1...7 { // Week 1
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56"), "Today’s activities expire in 12:34:56")
+        }
+        for dayIdx in 8...21 { // Week 2
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56"), "Daily activities expire in 12:34:56")
+        }
+    }
+    
+    func testDayTitleLabelText() {
+        XCTAssertEqual(vc.dayLabelText(for: 1, week: 1), "1 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 2, week: 1), "2 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 3, week: 1), "3 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 4, week: 1), "4 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 5, week: 1), "5 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 6, week: 1), "6 of 7")
+        XCTAssertEqual(vc.dayLabelText(for: 7, week: 1), "7 of 7")
+        for dayIdx in 8...14 { // Week 2
+            XCTAssertEqual(vc.dayLabelText(for: dayIdx, week: 2), "2")
+        }
+        for dayIdx in 15...21 { // Week 3
+            XCTAssertEqual(vc.dayLabelText(for: dayIdx, week: 3), "3")
+        }
+    }
+    
+    func testDayLabelText() {
+        for dayIdx in 1...7 { // Week 1
+            XCTAssertEqual(vc.dayTitleLabelText(for: dayIdx), "Day")
+        }
+        for dayIdx in 8...15 { // Week 2 and first day of Week 3
+            XCTAssertEqual(vc.dayTitleLabelText(for: dayIdx), "Week")
+        }
+    }
+    
+    func testExpiresTimeWeeklyText() {
+        for dayIdx in 1...7 { // Week 1, hide weekly expiration text
+            XCTAssertNil(vc.expiresWeeklyLabelText(for: dayIdx, week: 1, expiresTimeStr: "12:34:56"))
+        }
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 8, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 7 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 9, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 6 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 10, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 5 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 11, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 4 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 12, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 3 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 13, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 2 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 14, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 12:34:56")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 15, week: 3, expiresTimeStr: "12:34:56"), "Weekly activities expire in 7 days")
+    }
+    
     private func date(_ day: Int, _ hour: Int, _ min: Int, _ sec: Int) -> Date {
         return Calendar.current.date(from: DateComponents(year: 2019, month: 8, day: day, hour: hour, minute: min, second: sec))!
     }

--- a/BiomarinPKU/BiomarinPKUStudyTests/ActivityViewControllerTests.swift
+++ b/BiomarinPKU/BiomarinPKUStudyTests/ActivityViewControllerTests.swift
@@ -70,11 +70,19 @@ class ActivityViewControllerTests: XCTestCase {
     }
     
     func testExpiresLabelText() {
+        // Expire test
         for dayIdx in 1...7 { // Week 1
-            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56"), "Today’s activities expire in 12:34:56")
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56", allComplete: false), "Today’s activities expire in 12:34:56")
         }
-        for dayIdx in 8...21 { // Week 2
-            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56"), "Daily activities expire in 12:34:56")
+        for dayIdx in 8...21 { // Week 2-3
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56", allComplete: false), "Daily activities expire in 12:34:56")
+        }
+        // Renew test
+        for dayIdx in 1...7 { // Week 1
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56", allComplete: true), "Today’s activities renew in 12:34:56")
+        }
+        for dayIdx in 8...21 { // Week 2-3
+            XCTAssertEqual(vc.expiresLabelText(for: dayIdx, expiresTimeStr: "12:34:56", allComplete: true), "Daily activities renew in 12:34:56")
         }
     }
     
@@ -105,16 +113,72 @@ class ActivityViewControllerTests: XCTestCase {
     
     func testExpiresTimeWeeklyText() {
         for dayIdx in 1...7 { // Week 1, hide weekly expiration text
-            XCTAssertNil(vc.expiresWeeklyLabelText(for: dayIdx, week: 1, expiresTimeStr: "12:34:56"))
+            XCTAssertNil(vc.expiresWeeklyLabelText(for: dayIdx, week: 1, expiresTimeStr: "12:34:56", allComplete: false))
         }
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 8, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 7 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 9, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 6 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 10, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 5 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 11, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 4 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 12, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 3 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 13, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 2 days")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 14, week: 2, expiresTimeStr: "12:34:56"), "Weekly activities expire in 12:34:56")
-        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 15, week: 3, expiresTimeStr: "12:34:56"), "Weekly activities expire in 7 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 8, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 7 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 9, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 6 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 10, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 5 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 11, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 4 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 12, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 3 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 13, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 2 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 14, week: 2, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 12:34:56")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 15, week: 3, expiresTimeStr: "12:34:56", allComplete: false), "Weekly activities expire in 7 days")
+        
+        for dayIdx in 1...7 { // Week 1, hide weekly expiration text
+            XCTAssertNil(vc.expiresWeeklyLabelText(for: dayIdx, week: 1, expiresTimeStr: "12:34:56", allComplete: true))
+        }
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 8, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 7 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 9, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 6 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 10, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 5 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 11, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 4 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 12, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 3 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 13, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 2 days")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 14, week: 2, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 12:34:56")
+        XCTAssertEqual(vc.expiresWeeklyLabelText(for: 15, week: 3, expiresTimeStr: "12:34:56", allComplete: true), "Weekly activities renew in 7 days")
+    }
+    
+    func testActivityDetailText() {
+        for dayIdx in 1...7 {
+            XCTAssertEqual(ActivityType.daily.detail(for: dayIdx, isComplete: false), "1 minute")
+            XCTAssertEqual(ActivityType.sleep.detail(for: dayIdx, isComplete: false), "1 minute")
+            XCTAssertEqual(ActivityType.cognition.detail(for: dayIdx, isComplete: false), "6 minutes")
+            XCTAssertEqual(ActivityType.physical.detail(for:dayIdx, isComplete: false), "3 minutes")
+            
+            XCTAssertEqual(ActivityType.daily.detail(for: dayIdx, isComplete: true), "Done for day")
+            XCTAssertEqual(ActivityType.sleep.detail(for: dayIdx, isComplete: true), "Done for day")
+            XCTAssertEqual(ActivityType.cognition.detail(for: dayIdx, isComplete: true), "Done for day")
+            XCTAssertEqual(ActivityType.physical.detail(for: dayIdx, isComplete: true), "Done for day")
+        }
+        
+        for dayIdx in 8...14 {
+            XCTAssertEqual(ActivityType.daily.detail(for: dayIdx, isComplete: false), "1 minute")
+            XCTAssertEqual(ActivityType.sleep.detail(for: dayIdx, isComplete: false), "1 minute")
+            XCTAssertEqual(ActivityType.cognition.detail(for: dayIdx, isComplete: false), "6 minutes")
+            XCTAssertEqual(ActivityType.physical.detail(for:dayIdx, isComplete: false), "3 minutes")
+            
+            XCTAssertEqual(ActivityType.daily.detail(for: dayIdx, isComplete: true), "Done for day")
+            XCTAssertEqual(ActivityType.sleep.detail(for: dayIdx, isComplete: true), "Done for day")
+            XCTAssertEqual(ActivityType.cognition.detail(for: dayIdx, isComplete: true), "Done for week")
+            XCTAssertEqual(ActivityType.physical.detail(for: dayIdx, isComplete: true), "Done for week")
+        }
+    }
+    
+    func testHeaderTitle() {
+        for dayIdx in 1...7 { // Week 1
+            XCTAssertEqual(vc.headerTitle(for: dayIdx), "Let’s begin your journey!")
+        }
+        for dayIdx in 8...15 { // Week 2 and first day of Week 3
+            XCTAssertEqual(vc.headerTitle(for: dayIdx), "Continuing your journey")
+        }
+    }
+    
+    func testHeaderText() {
+        for dayIdx in 1...7 { // Week 1
+            XCTAssertEqual(vc.headerText(for: dayIdx), "By completing your first 4 activities in a day for one week, you will then be able to unlock your entire journey.")
+        }
+        for dayIdx in 8...15 { // Week 2 and first day of Week 3
+            XCTAssertEqual(vc.headerText(for: dayIdx), "In this phase of the study, please do your check-ins once per day and your challenges once per week.")
+        }
     }
     
     private func date(_ day: Int, _ hour: Int, _ min: Int, _ sec: Int) -> Date {


### PR DESCRIPTION
Completed state changes for home screen after week 1.  

Re-organized the activities so that daily and sleep are always in the top row, and cognitive and physical challenges are now in the bottom row.

After week 1 the following UI changes happen...
1) The "today's activities expire in..." label now starts with "Daily activities expire in..."2) There is a new weekly expires in label that shows up above the cognitive and physical challenges.  On first 6 days of the week it says "Weekly activities expire in X days".  On the last day of the week it says "Weekly activities expire in 05:12:00" which is an hour, min, sec countdown like the daily expiration label.3) Instead of Day 1 of 7, that label should now show week number, like "Week 2"4) Physical and cognitive challenge actives should stay as marked "Done" with the checkmark until the next week.

See [Jira Issue](https://sagebionetworks.jira.com/browse/PKU-134) for a video of it working
