### PR TITLE
PKU-170

### DIFF
--- a/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityViewController.swift
@@ -261,6 +261,11 @@ class ActivityViewController: UIViewController, RSDTaskViewControllerDelegate {
     }
     
     @IBAction func physicalTapped() {
+        // Work-around fix for permission bug
+        // This will force the overview screen to check permission state every time
+        // Usually research framework caches it and the state becomes invalid
+        UserDefaults.standard.removeObject(forKey: "rsd_MotionAuthorizationStatus")
+        
         self.presentTaskViewController(for: .physical)
     }
     

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "da1d0f6bdf2fd51259e3219a824b106210908b92"
 github "Sage-Bionetworks/BridgeApp-Apple-SDK" "v3.0.6"
-github "Sage-Bionetworks/SageResearch" "v2.4.66"
+github "Sage-Bionetworks/SageResearch" "v2.4.67"
 github "dephillipsmichael/MotorControl-iOS" "19b81fd5c0f34cc231cf4754bfce2c333014568d"


### PR DESCRIPTION
Edge case permission fix.  This forces the overview screen check for permissions every time so that it is always up to date with the current state of authorization.  If authorization is denied, they are not allowed to continue past the overview screen.