### PR TITLE
PKU-180

### DIFF
--- a/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
+++ b/BiomarinPKU/BiomarinPKU-Study/ActivityScheduleManager.swift
@@ -56,11 +56,23 @@ public class ActivityScheduleManager : SBAScheduleManager {
         return ActivityType.daily.weekOfStudy(dayOfStudy: dayOfStudy)
     }
     
-    open var studyStartDate: Date {
+    open var studyStartDate: Date {            
         // The activites are scheduled when the user first requests them
         // Therefore, the day the user first signed in and started their study,
         // is the date that we can use as the study start date
-        return self.scheduledActivities.first?.scheduledOn.startOfDay() ?? today.startOfDay()
+        
+        // Ideally, Bridge will only ever issue the scheduled actvities once,
+        // But a bug was introduced temporarily that was causing the
+        // scheduled activities to not be ordered by oldest first.
+        // To prevent this in the future, we search all the scheduled activities
+        // and return the oldest date as the study start date
+        return self.scheduledActivities.reduce(today.startOfDay()) { (earliestDate, activity) -> Date in
+            let scheduledOnStartOfDay = activity.scheduledOn.startOfDay()
+            if scheduledOnStartOfDay < earliestDate {
+                return scheduledOnStartOfDay
+            }
+            return earliestDate
+        }
     }
     
     public let endOfStudySortOrder: [RSDIdentifier] =

--- a/BiomarinPKU/BiomarinPKUStudyTests/ActivityScheduleManagerTests.swift
+++ b/BiomarinPKU/BiomarinPKUStudyTests/ActivityScheduleManagerTests.swift
@@ -42,7 +42,6 @@ class ActivityScheduleManagerTests: XCTestCase {
     let scheduleManager = TestableWeek1ScheduleManager()
     
     let PKUStudyTaskIdentifiers = [
-        "RestingKineticTremor",
         "Attentional Blink",
         "Daily Check-In",
         "Sleep Check-In",


### PR DESCRIPTION
@DanWebster this needs tested on a production account that was being effected; however, I was afraid to log in as one of them, because I figured it would invalidate their fitbit credentials and auth token.  How do you think the best way verify is?

From the aftermath of some user's having their ScheduledActivities re-created, I added an extra layer of protection when calculating study start date.  The study start date is now a more in-depth calculation that will always return the oldest scheduledOn date, which will be the true study start date.

A unit test has been added to explicitly test this scenario, and it is running successfully now after the code change.
